### PR TITLE
Send OC proto trace data to 1Agent via json socket

### DIFF
--- a/OpenCensusAgent/opencensus-service/startReceiving.py
+++ b/OpenCensusAgent/opencensus-service/startReceiving.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python
+import os
+
+myCmd = 'make agent && ./bin/ocagent_linux'
+os.system(myCmd)


### PR DESCRIPTION
Once OpenCensus receiver retrieves OC proto data, my function `SendTraceTo1Agent` sends it through a json socket to 1Agent. This was tested by checking that the 1Agent transfered the data to a file under /tmp in my local machine. 

@reyang @simathih