### PR TITLE
Send OC Go Span data in App Insights format to 1Agent via json socket

### DIFF
--- a/OpenCensusAgent/opencensus-service/exporter/exporterwrapper/converterToApplicationInsights.go
+++ b/OpenCensusAgent/opencensus-service/exporter/exporterwrapper/converterToApplicationInsights.go
@@ -35,7 +35,7 @@ func ConvertOCSpanDataToApplicationInsightsSchema(sd *trace.SpanData) string {
 
 	envelope.Tags["ai.operation.id"] = sd.SpanContext.TraceID.String()
 	if sd.ParentSpanID.String() != "0000000000000000" {
-		envelope.Tags["ai.operation.parentId"] = "|" + sd.SpanContext.TraceID.String() + "." + sd.ParentSpanID.String()
+		envelope.Tags["ai.operation.parentId"] = "|" + sd.SpanContext.TraceID.String() + "." + sd.ParentSpanID.String() + "."
 	}
 	if sd.SpanKind == trace.SpanKindServer {
 		envelope.Name = "Microsoft.ApplicationInsights.Request"

--- a/OpenCensusAgent/opencensus-service/receiver/opencensusreceiver/octrace/opencensus.go
+++ b/OpenCensusAgent/opencensus-service/receiver/opencensusreceiver/octrace/opencensus.go
@@ -15,16 +15,9 @@
 package octrace
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
-	"log"
-	"net"
-	"strconv"
-	"time"
 
 	"go.opencensus.io/trace"
 
@@ -97,55 +90,6 @@ var errTraceExportProtocolViolation = errors.New("protocol violation: Export's f
 
 const receiverTagValue = "oc_trace"
 
-type mdsdJSON struct {
-	Tag    string   `json:"TAG"` // Tag is used to see if acknowledged by 1Agent
-	Source string   `json:"SOURCE"`
-	Data   []string `json:"DATA"` // Data must be an array
-}
-
-// SendTraceTo1Agent makes a connection to 1Agent and passes in the OpenCensus proto trace in JSON format
-func SendTraceTo1Agent(td *data.TraceData) {
-	log.Println("Starting funnel of data.")
-
-	conn, err := net.Dial("unix", "/var/run/mdsd/default_json.socket")
-	if err != nil {
-		log.Printf("Error connecting: %v", err)
-		return
-	}
-	traceData, err := json.Marshal(td)
-	if err != nil {
-		log.Printf("Error marshaling trace data: %v", err)
-		return
-	}
-	dataList := []string{
-		string(traceData), //WholeTrace, this part is defined in schema found in mdsd.xml
-	}
-	id := time.Now().UTC()
-
-	trace := new(mdsdJSON)
-	trace.Tag = strconv.FormatInt(id.Unix(), 10) // Use time to create a unique Tag
-	trace.Source = "funnel"                      // "funnel" defined in schema
-	trace.Data = dataList
-
-	byteData, err := json.Marshal(trace)
-	if err != nil {
-		log.Printf("Error marshaling mdsdJSON: %v", err)
-		return
-	}
-	_, err = conn.Write(byteData)
-	if err != nil {
-		log.Printf("Error writing to 1Agent: %v", err)
-		return
-	}
-	reader := bufio.NewReader(conn)
-	line, err := reader.ReadString('\n')
-	if err != nil {
-		log.Printf("Error reading 1Agent connection:%v", err)
-		return
-	}
-	fmt.Println(line) // Tag returned from 1Agent
-}
-
 // Export is the gRPC method that receives streamed traces from
 // OpenCensus-traceproto compatible libraries/applications.
 func (ocr *Receiver) Export(tes agenttracepb.TraceService_ExportServer) error {
@@ -184,7 +128,6 @@ func (ocr *Receiver) Export(tes agenttracepb.TraceService_ExportServer) error {
 			Spans:        recv.Spans,
 			SourceFormat: "oc_trace",
 		}
-		SendTraceTo1Agent(td)
 
 		ocr.messageChan <- &traceDataWithCtx{data: td, ctx: ctxWithReceiverName}
 


### PR DESCRIPTION
It makes more sense to send trace data to 1Agent **after** it is converterd to Application Insights format, so I moved the sink code to where this conversion occurs instead.

@reyang @simathih