### PR TITLE
Fix parent id format in copied code to connect child spans

### DIFF
--- a/OpenCensusAgent/opencensus-service/exporter/exporterwrapper/converterToApplicationInsights.go
+++ b/OpenCensusAgent/opencensus-service/exporter/exporterwrapper/converterToApplicationInsights.go
@@ -35,7 +35,7 @@ func ConvertOCSpanDataToApplicationInsightsSchema(sd *trace.SpanData) string {
 
 	envelope.Tags["ai.operation.id"] = sd.SpanContext.TraceID.String()
 	if sd.ParentSpanID.String() != "0000000000000000" {
-		envelope.Tags["ai.operation.parentId"] = "|" + sd.SpanContext.TraceID.String() + "." + sd.ParentSpanID.String()
+		envelope.Tags["ai.operation.parentId"] = "|" + sd.SpanContext.TraceID.String() + "." + sd.ParentSpanID.String() + "."
 	}
 	if sd.SpanKind == trace.SpanKindServer {
 		envelope.Name = "Microsoft.ApplicationInsights.Request"


### PR DESCRIPTION
The code I copied from here https://github.com/ChrisCoe/opencensus-go/tree/master/exporter/azure_monitor for the conversion logic has a bug. I fixed it on my local machine a while back, but never pushed it to my repo. I will make another PR to fix this code from the source.

With this change, I can now have parent child spans linked together on Azure Monitor dashboard when they are sent from the 1Agent. 

@reyang @simathih