### PR TITLE
Increase time resolution for spans to have unique tag

### DIFF
--- a/OpenCensusAgent/opencensus-service/exporter/exporterwrapper/exporterwrapper.go
+++ b/OpenCensusAgent/opencensus-service/exporter/exporterwrapper/exporterwrapper.go
@@ -103,7 +103,7 @@ func SendSpanTo1Agent(spanData string) {
 	id := time.Now().UTC()
 
 	trace := new(mdsdJSON)
-	trace.Tag = strconv.FormatInt(id.Unix(), 10) // Use time to create a unique Tag
+	trace.Tag = strconv.FormatInt(id.UnixNano(), 10) // Use time to create a unique Tag
 	trace.Source = "funnel"                      // "funnel" defined in schema
 	trace.Data = dataList
 


### PR DESCRIPTION
As mentioned in this PR https://github.com/ChrisCoe/azure-linux-extensions/pull/3, time resolution should be more precise. Some data I am sending is now happening at a subsecond level, so I updated the tag from second to nanosecond.

@simathih @canfikret